### PR TITLE
SVC-3406

### DIFF
--- a/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxHostedServiceTest.cs
+++ b/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxHostedServiceTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
     public class OutboxHostedServiceTest {
         private readonly ServiceCollection services;
-        private readonly Mock<IDomainEventPublisher> publisher;
+        private readonly Mock<IDomainEventPublisherSession> publisher;
         private readonly Outbox outbox;
         private readonly EntityContext context;
 
@@ -32,7 +32,8 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
             context.Set<Outbox>().Add(outbox);
             context.SaveChanges();
             services.AddSingleton(context);
-            publisher = new Mock<IDomainEventPublisher>();
+            publisher = new Mock<IDomainEventPublisherSession>();
+            publisher.Setup(x => x.BeginSession()).Returns(publisher.Object);
         }
 
         [Fact]

--- a/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxHostedServiceTest.cs
+++ b/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxHostedServiceTest.cs
@@ -28,7 +28,7 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
                 .UseInMemoryDatabase($"OutboxHostedService-{Guid.NewGuid()}")
                 .Options;
             context = new EntityContext(options);
-            outbox = new Outbox() { EventType = "foo", Topic = "bar", RoutingKey = "baz", Body = "{}", CorrelationId = Guid.NewGuid().ToString(), MessageId = Guid.NewGuid().ToString(), LockId = null };
+            outbox = new Outbox() { EventType = "foo", Topic = "bar", RoutingKey = "baz", Body = "{}", CorrelationId = Guid.NewGuid().ToString(), MessageId = Guid.NewGuid().ToString(), LockId = null, RemainingAttempts = 3 };
             context.Set<Outbox>().Add(outbox);
             context.SaveChanges();
             services.AddSingleton(context);
@@ -40,7 +40,7 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
             publisher.Setup(x => x.PublishAsync(outbox.Body, It.IsAny<EventProperties>()));
             services.AddSingleton<IDomainEventPublisher>(publisher.Object);
             services.AddSingleton(new ReceiverHostedServiceSettings() { Enabled = true, MessageTypes = [] });
-            services.AddSingleton(new OutboxHostedServiceConfiguration() { Enabled = true, Interval = 1, BatchSize = 1000, PurgePublished = false });
+            services.AddSingleton(new OutboxHostedServiceConfiguration() { Enabled = true, Interval = 1, BatchSize = 1000, PurgePublished = false, MaximumPublishCount = 3 });
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -64,7 +64,7 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
         [Fact]
         public async Task ShouldSuccessfullyPublishKeyedMessageAsync() {
             var key = "connectionKey";
-            var keyedoutbox = new Outbox() { Key = key, EventType = "foo", Topic = "bar", RoutingKey = "baz", Body = "{}", CorrelationId = Guid.NewGuid().ToString(), MessageId = Guid.NewGuid().ToString(), LockId = null };
+            var keyedoutbox = new Outbox() { Key = key, EventType = "foo", Topic = "bar", RoutingKey = "baz", Body = "{}", CorrelationId = Guid.NewGuid().ToString(), MessageId = Guid.NewGuid().ToString(), LockId = null, RemainingAttempts = 10 };
             context.Set<Outbox>().Add(keyedoutbox);
             await context.SaveChangesAsync();
             publisher.Setup(x => x.PublishAsync(outbox.Body, It.IsAny<EventProperties>()));
@@ -159,7 +159,6 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
             services.AddSingleton(new OutboxHostedServiceConfiguration() { Enabled = true, Interval = 1, BatchSize = 1000, PurgePublished = false, MaximumPublishCount = 3 });
 
             var serviceProvider = services.BuildServiceProvider();
-
             var service = serviceProvider.GetService<IHostedService>() as OutboxHostedService<EntityContext>;
 
             using var source = new CancellationTokenSource();

--- a/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxPublisherTest.cs
+++ b/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/OutboxPublisherTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cortside.DomainEvent.EntityFramework.Hosting;
 using Cortside.DomainEvent.EntityFramework.IntegrationTests.Database;
 using Cortside.DomainEvent.EntityFramework.IntegrationTests.Events;
 using Microsoft.EntityFrameworkCore;
@@ -28,6 +29,7 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
             services.AddSingleton(context);
 
             services.AddSingleton(new DomainEventPublisherSettings() { Topic = "topic." });
+            services.AddSingleton(new OutboxHostedServiceConfiguration() { MaximumPublishCount = 3 });
             services.AddTransient<IDomainEventOutboxPublisher, DomainEventOutboxPublisher<EntityContext>>();
 
             provider = services.BuildServiceProvider();
@@ -273,9 +275,10 @@ namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
                     new StringEnumConverter(new SnakeCaseNamingStrategy())
                 }
             };
+            var outboxHostedServiceConfiguration = provider.GetService<OutboxHostedServiceConfiguration>();
 
             var db = provider.GetService<EntityContext>();
-            var publisher = new DomainEventOutboxPublisher<EntityContext>(settings, db, new NullLogger<DomainEventOutboxPublisher<EntityContext>>());
+            var publisher = new DomainEventOutboxPublisher<EntityContext>(settings, outboxHostedServiceConfiguration, db, new NullLogger<DomainEventOutboxPublisher<EntityContext>>());
 
             var correlationId = Guid.NewGuid().ToString();
             var messageId = Guid.NewGuid().ToString();

--- a/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/ServiceCollectionExtensionsTest.cs
+++ b/src/Cortside.DomainEvent.EntityFramework.IntegrationTests/ServiceCollectionExtensionsTest.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
-namespace Cortside.DomainEvent.Tests {
+namespace Cortside.DomainEvent.EntityFramework.IntegrationTests {
     public class ServiceCollectionExtensionsTest {
         [Fact]
         public void AddDomainEventOutboxPublisherLegacy() {

--- a/src/Cortside.DomainEvent.EntityFramework/Cortside.DomainEvent.EntityFramework.csproj
+++ b/src/Cortside.DomainEvent.EntityFramework/Cortside.DomainEvent.EntityFramework.csproj
@@ -34,6 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+    <PackageReference Include="UUIDNext" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cortside.DomainEvent.EntityFramework/DomainEventOutboxPublisher.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/DomainEventOutboxPublisher.cs
@@ -37,6 +37,10 @@ namespace Cortside.DomainEvent.EntityFramework {
 
         public event PublisherClosedCallback Closed;
 
+        public IDomainEventPublisherSession BeginSession() {
+            throw new NotImplementedException("This publisher does not support sessions");
+        }
+
         public Task PublishAsync<T>(T @event) where T : class {
             var properties = new EventProperties();
             return InnerSendAsync(@event, properties);

--- a/src/Cortside.DomainEvent.EntityFramework/Hosting/EventTypeOverride.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Hosting/EventTypeOverride.cs
@@ -2,6 +2,5 @@ namespace Cortside.DomainEvent.EntityFramework.Hosting {
     public class EventTypeOverride {
         public string EventType { get; set; }
         public int MaximumPublishCount { get; set; }
-        public int PublishRetryInterval { get; set; }
     }
 }

--- a/src/Cortside.DomainEvent.EntityFramework/Hosting/EventTypeOverride.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Hosting/EventTypeOverride.cs
@@ -1,0 +1,7 @@
+namespace Cortside.DomainEvent.EntityFramework.Hosting {
+    public class EventTypeOverride {
+        public string EventType { get; set; }
+        public int MaximumPublishCount { get; set; }
+        public int PublishRetryInterval { get; set; }
+    }
+}

--- a/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedService.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedService.cs
@@ -51,10 +51,10 @@ if (@rows > 0)
     SET TRANSACTION ISOLATION LEVEL READ COMMITTED
 
     UPDATE Q
-    SET LockId = case when RemainingAttempts > 0 then null else '{lockId}' end,
-        Status=case when RemainingAttempts > 0 then 'Failed' else 'Publishing' end,
+    SET LockId = case when RemainingAttempts > 0 then '{lockId}' else null end,
+        Status=case when RemainingAttempts > 0 then '{OutboxStatus.Publishing}' else '{OutboxStatus.Failed}' end,
         LastModifiedDate=GETUTCDATE(),
-        PublishCount=PublishCount+case when RemainingAttempts > 0 then 0 else 1 end,
+        PublishCount=PublishCount+case when RemainingAttempts > 0 then 1 else 0 end,
         RemainingAttempts=case when RemainingAttempts > 0 then RemainingAttempts-1 else 0 end
     FROM (
             select top ({config.BatchSize}) * from Outbox

--- a/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedService.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedService.cs
@@ -32,10 +32,24 @@ namespace Cortside.DomainEvent.EntityFramework.Hosting {
             return base.StartAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Execute interval until there are no messages to process
+        /// </summary>
+        /// <returns></returns>
         protected override async Task ExecuteIntervalAsync() {
+            do {
+                var messageCount = await IntervalAsync();
+                if (messageCount == 0) {
+                    break;
+                }
+            } while (true);
+        }
+
+        private async Task<int> IntervalAsync() {
             logger.LogDebug("{Key} OutboxHostedService ExecuteIntervalAsync() entered.", Key);
             await Task.Yield();
             var keySql = (!string.IsNullOrWhiteSpace(Key)) ? $" and [Key]='{Key}' " : "";
+            int messageCount;
 
             var lockId = Uuid.NewDatabaseFriendly(Database.SqlServer);
             var sql = $@"
@@ -79,7 +93,6 @@ if (@rows > 0)
 
                 logger.LogDebug("Obtained DbContext with provider {ProviderName}, IsRelational = {IsRelational}", db.Database.ProviderName, isRelational);
 
-                int messageCount;
                 if (isRelational) {
                     messageCount = await db.Database.ExecuteSqlRawAsync(sql).ConfigureAwait(false);
                 } else {
@@ -109,39 +122,47 @@ if (@rows > 0)
                     List<Outbox> messages = await db.Set<Outbox>().Where(x => x.LockId == lockId).ToListAsync().ConfigureAwait(false);
                     logger.LogInformation("{Key} Messages claimed: {Count}", Key, messages.Count);
 
-                    var i = 1;
-                    foreach (var message in messages) {
-                        logger.LogDebug("{Key} Publishing message {MessageId} [OutboxId: {OutboxId}] ({Index} of {Count})", Key, message.MessageId, message.OutboxId, i, messages.Count);
-                        var properties = new EventProperties() {
-                            EventType = message.EventType,
-                            Topic = message.Topic,
-                            RoutingKey = message.RoutingKey,
-                            CorrelationId = message.CorrelationId,
-                            MessageId = message.MessageId
-                        };
+                    logger.LogTrace("Getting IDomainEventPublisher instance");
+                    var publisher = (!string.IsNullOrWhiteSpace(Key)) ? scope.ServiceProvider.GetKeyedService<IDomainEventPublisher>(Key) : scope.ServiceProvider.GetService<IDomainEventPublisher>();
+                    logger.LogTrace($"Obtained IDomainEventPublisher instance with type of {publisher.GetType().Name}");
 
-                        logger.LogTrace("Getting IDomainEventPublisher instance");
-                        var publisher = (!string.IsNullOrWhiteSpace(Key)) ? scope.ServiceProvider.GetKeyedService<IDomainEventPublisher>(Key) : scope.ServiceProvider.GetService<IDomainEventPublisher>();
-                        logger.LogTrace($"Obtained IDomainEventPublisher instance with type of {publisher.GetType().Name}");
+                    using (var session = publisher.BeginSession()) {
+                        var i = 1;
+                        foreach (var message in messages) {
+                            logger.LogDebug(
+                                "{Key} Publishing message {MessageId} [OutboxId: {OutboxId}] ({Index} of {Count})", Key,
+                                message.MessageId, message.OutboxId, i, messages.Count);
+                            var properties = new EventProperties() {
+                                EventType = message.EventType,
+                                Topic = message.Topic,
+                                RoutingKey = message.RoutingKey,
+                                CorrelationId = message.CorrelationId,
+                                MessageId = message.MessageId
+                            };
 
-                        try {
-                            await publisher.PublishAsync(message.Body, properties).ConfigureAwait(false);
-                            message.Status = OutboxStatus.Published;
-                            message.PublishedDate = DateTime.UtcNow;
-                            message.LockId = null;
+                            try {
+                                await session.PublishAsync(message.Body, properties).ConfigureAwait(false);
+                                message.Status = OutboxStatus.Published;
+                                message.PublishedDate = DateTime.UtcNow;
+                                message.LockId = null;
 
-                            logger.LogTrace("Saving changes for message {message.MessageId}");
-                            await db.SaveChangesAsync().ConfigureAwait(false);
-                            logger.LogTrace("Saved changes for message {message.MessageId}");
-                        } catch (Exception ex) {
-                            // set message back to original locked state -- just in case the exception is from ef
-                            db.Entry(message).State = EntityState.Unchanged;
+                                logger.LogTrace("Saving changes for message {message.MessageId}");
+                                await db.SaveChangesAsync().ConfigureAwait(false);
+                                logger.LogTrace("Saved changes for message {message.MessageId}");
+                            } catch (Exception ex) {
+                                // set message back to original locked state -- just in case the exception is from ef
+                                db.Entry(message).State = EntityState.Unchanged;
 
-                            logger.LogError(ex, "Exception attempting to publish message {MessageId} from outbox: {Reason}", message.MessageId, ex.Message);
+                                logger.LogError(ex,
+                                    "Exception attempting to publish message {MessageId} from outbox: {Reason}",
+                                    message.MessageId, ex.Message);
+                            }
+
+                            logger.LogDebug(
+                                "{Key} Published message {MessageId} [OutboxId: {OutboxId}] ({Index} of {Count})", Key,
+                                message.MessageId, message.OutboxId, i, messages.Count);
+                            i++;
                         }
-
-                        logger.LogDebug("{Key} Published message {MessageId} [OutboxId: {OutboxId}] ({Index} of {Count})", Key, message.MessageId, message.OutboxId, i, messages.Count);
-                        i++;
                     }
                 } catch (Exception ex) {
                     logger.LogError(ex, "Exception attempting to publish from outbox: {Reason}", ex.Message);
@@ -166,6 +187,8 @@ if (@rows > 0)
 
                 logger.LogDebug("OutboxHostedService ExecuteIntervalAsync() completed.");
             }
+
+            return messageCount;
         }
     }
 }

--- a/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedServiceConfiguration.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Hosting/OutboxHostedServiceConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Cortside.DomainEvent.EntityFramework.Hosting {
     public class OutboxHostedServiceConfiguration {
         public int BatchSize { get; set; }
@@ -6,5 +8,7 @@ namespace Cortside.DomainEvent.EntityFramework.Hosting {
         public bool PurgePublished { get; set; }
         public int MaximumPublishCount { get; set; } = 10;
         public int PublishRetryInterval { get; set; } = 60;
+
+        public List<EventTypeOverride> Overrides { get; set; }
     }
 }

--- a/src/Cortside.DomainEvent.EntityFramework/ModelBuilderExtensions.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/ModelBuilderExtensions.cs
@@ -54,8 +54,8 @@ namespace Cortside.DomainEvent.EntityFramework {
                     v => (OutboxStatus)Enum.Parse(typeof(OutboxStatus), v)
                 );
 
-            builder.Property(t => t.LockId)
-                    .HasMaxLength(36);
+            builder.Property(t => t.RemainingAttempts)
+                .HasDefaultValue(10);
 
             builder.HasIndex(p => new { p.ScheduledDate, p.Status })
                 .IncludeProperties(p => new { p.EventType })

--- a/src/Cortside.DomainEvent.EntityFramework/Outbox.cs
+++ b/src/Cortside.DomainEvent.EntityFramework/Outbox.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -43,8 +44,7 @@ namespace Cortside.DomainEvent.EntityFramework {
 
         public DateTime? PublishedDate { get; set; }
 
-        [StringLength(36)]
-        public string LockId { get; set; }
+        public Guid? LockId { get; set; }
 
         [Required]
         public DateTime LastModifiedDate { get; set; } = DateTime.UtcNow;
@@ -53,5 +53,9 @@ namespace Cortside.DomainEvent.EntityFramework {
 
         [StringLength(50)]
         public string Key { get; set; }
+
+        [Required]
+        [DefaultValue(10)]
+        public int RemainingAttempts { get; set; }
     }
 }

--- a/src/Cortside.DomainEvent.EntityFramework/README.md
+++ b/src/Cortside.DomainEvent.EntityFramework/README.md
@@ -32,6 +32,8 @@ OutboxHostedService": {
 }
 ```
 
+The OutboxHostedService will publish outbox messages in batches.  It will retry messages that have failed up to the MaximumPublishCount.  Message publish count can be overridden for specific messages and will be used if found.
+
 ### sql to create table if not using migrations
 
 ```sql
@@ -46,10 +48,14 @@ OutboxHostedService": {
         [CreatedDate] datetime2 NOT NULL,
         [ScheduledDate] datetime2 NOT NULL,
         [PublishedDate] datetime2 NULL,
-        [LockId] nvarchar(36) NULL,
+        [LockId] uniqueidentifier NULL,
         [PublishCount] int NOT NULL DEFAULT 0,
+        [Key] nvarchar(50) NULL,
+        [RemainingAttempts] int NOT NULL DEFAULT 10
         CONSTRAINT [PK_Outbox] PRIMARY KEY ([MessageId])
     );
 
    CREATE INDEX [IX_ScheduleDate_Status] ON [dbo].[Outbox] ([ScheduledDate], [Status]) INCLUDE ([EventType]);
+
+   CREATE INDEX [IX_Status_LastModifiedDate] ON [dbo].[Outbox] ([Status], [LastModifiedDate]);
 ```

--- a/src/Cortside.DomainEvent.EntityFramework/README.md
+++ b/src/Cortside.DomainEvent.EntityFramework/README.md
@@ -18,7 +18,17 @@ OutboxHostedService": {
     "Interval": 5,
     "PurgePublished": true,
     "MaximumPublishCount": 10,
-    "PublishRetryInterval": 60
+    "PublishRetryInterval": 60,
+    "Overrides": [
+        {
+            "EventType": "MyEvent",
+            "MaximumPublishCount": 5
+        },
+        {
+            "EventType": "OtherEvent",
+            "MaximumPublishCount": 10
+        }
+    ]
 }
 ```
 

--- a/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
+++ b/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using Cortside.AspNetCore.Common.Paging;
+using Cortside.Common.Logging;
+using Cortside.DomainEvent.EntityFramework;
+using Cortside.DomainEvent.EntityFramework.Hosting;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Cortside.DomainEvent.Mvc.Controllers {
+    /// <summary>
+    /// Outbox controller
+    /// </summary>
+    [ApiVersionNeutral]
+    [Route("api/outbox/messages")]  // TODO: need to make this configurable
+    [ApiController]
+    [Produces("application/json")]
+    public class OutboxController<T> : ControllerBase where T : DbContext {
+        private readonly ILogger<OutboxController<T>> logger;
+        private readonly T db;
+        private readonly OutboxHostedServiceConfiguration configuration;
+
+        /// <summary>
+        /// OutboxController
+        /// </summary>
+        public OutboxController(ILogger<OutboxController<T>> logger, T databaseContext, OutboxHostedServiceConfiguration configuration) {
+            this.logger = logger;
+            db = databaseContext;
+            this.configuration = configuration;
+        }
+
+        /// <summary>
+        /// Get failed messages
+        /// </summary>
+        [HttpGet("")]
+        [Authorize("GetOutboxMessages")]
+        [ProducesResponseType(typeof(PagedList<Outbox>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMessagesAsync([FromQuery] int pageNumber, int pageSize) {
+            var messages = db.Set<Outbox>().Where(x => x.Status == OutboxStatus.Failed);
+
+            var result = new PagedList<Outbox> {
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalItems = await messages.CountAsync().ConfigureAwait(false),
+                Items = [],
+            };
+            result.Items = await messages.OrderBy(x => x.MessageId).Skip(result.PageSize * result.PageNumber).Take(result.PageSize).ToListAsync();
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Reset message attempts and status
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="input"></param>
+        [HttpPost("{id}/reset")]
+        [Authorize("ResetOutboxMessage")]
+        [ProducesResponseType(typeof(Outbox), StatusCodes.Status200OK)]
+        public async Task<IActionResult> ResetMessageAsync(string id) {
+            using (logger.PushProperty("MessageId", id)) {
+                var message = await db.Set<Outbox>().FirstOrDefaultAsync(x => x.MessageId == id);
+                if (message == null) {
+                    return NotFound();
+                }
+
+                message.Status = OutboxStatus.Queued;
+                var attempts = configuration.Overrides?.FirstOrDefault(x => x.EventType == message.EventType)?.MaximumPublishCount ?? configuration.MaximumPublishCount;
+                message.RemainingAttempts = attempts;
+                await db.SaveChangesAsync();
+
+                return Ok(message);
+            }
+        }
+
+        /// <summary>
+        /// Delete message
+        /// </summary>
+        /// <param name="resourceId"></param>
+        [HttpDelete("{id}")]
+        [Authorize("DeleteOutboxMessage")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> CancelOrderAsync(string id) {
+            using (logger.PushProperty("MessageId", id)) {
+                var message = await db.Set<Outbox>().FirstOrDefaultAsync(x => x.MessageId == id);
+                if (message == null) {
+                    return NotFound();
+                }
+
+                db.Remove(message);
+                await db.SaveChangesAsync();
+
+                return StatusCode((int)HttpStatusCode.NoContent);
+            }
+        }
+    }
+}

--- a/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
+++ b/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
@@ -40,7 +40,7 @@ namespace Cortside.DomainEvent.Mvc.Controllers {
         [HttpGet("")]
         [Authorize("GetOutboxMessages")]
         [ProducesResponseType(typeof(PagedList<Outbox>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetMessagesAsync([FromQuery] int pageNumber, int pageSize) {
+        public async Task<IActionResult> GetMessagesAsync([FromQuery] int pageNumber = 1, int pageSize = 30) {
             var messages = db.Set<Outbox>().Where(x => x.Status == OutboxStatus.Failed);
 
             var result = new PagedList<Outbox> {

--- a/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
+++ b/src/Cortside.DomainEvent.Mvc/Controllers/OutboxController.cs
@@ -20,15 +20,15 @@ namespace Cortside.DomainEvent.Mvc.Controllers {
     [Route("api/outbox/messages")]  // TODO: need to make this configurable
     [ApiController]
     [Produces("application/json")]
-    public class OutboxController<T> : ControllerBase where T : DbContext {
-        private readonly ILogger<OutboxController<T>> logger;
-        private readonly T db;
+    public class OutboxController : ControllerBase {
+        private readonly ILogger<OutboxController> logger;
+        private readonly DbContext db;
         private readonly OutboxHostedServiceConfiguration configuration;
 
         /// <summary>
         /// OutboxController
         /// </summary>
-        public OutboxController(ILogger<OutboxController<T>> logger, T databaseContext, OutboxHostedServiceConfiguration configuration) {
+        public OutboxController(ILogger<OutboxController> logger, DbContext databaseContext, OutboxHostedServiceConfiguration configuration) {
             this.logger = logger;
             db = databaseContext;
             this.configuration = configuration;

--- a/src/Cortside.DomainEvent.Mvc/Cortside.DomainEvent.Mvc.csproj
+++ b/src/Cortside.DomainEvent.Mvc/Cortside.DomainEvent.Mvc.csproj
@@ -1,0 +1,45 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
+    <PackageReference Include="Cortside.AspNetCore.Common" Version="8.0.317" />
+    <PackageReference Include="Cortside.Common.Correlation" Version="8.0.478">
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="Cortside.Common.Hosting" Version="8.0.478" />
+    <PackageReference Include="Cortside.Common.Logging" Version="8.0.478" />
+    <PackageReference Include="Cortside.Common.Validation" Version="8.0.478" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.3">
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3">
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cortside.DomainEvent.EntityFramework\Cortside.DomainEvent.EntityFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Cortside.DomainEvent.Mvc/README.md
+++ b/src/Cortside.DomainEvent.Mvc/README.md
@@ -2,21 +2,32 @@
 
 This library provides a controller to be able to interact with outbox messages that have failed.  Specifically to enumerate them, retry them, and delete them.
 
+
+Adding the controller to a service can be accomplished by the following:
+```csharp
+// add controllers and set api defaults
+var mvcBuilder = services.AddApiDefaults(InternalDateTimeHandling.Utc, options => {
+    options.Filters.Add<MessageExceptionResponseFilter>();
+});
+mvcBuilder.PartManager.ApplicationParts.Add(new AssemblyPart(typeof(OutboxController).Assembly));
+```
+
+
 ### Examples
 
-Get a list of outbox messages that have failed
+Get a list of outbox messages that have failed:
 ```bash
 curl --location 'localhost:5000/api/outbox/messages?pageNumber=1&pageSize=10' \
 --header 'Authorization: Bearer <token>'
 ```
 
-Reset an outbox message that has failed to queued with new attempts
+Reset an outbox message that has failed to queued with new attempts:
 ```bash
 curl --location --request POST 'localhost:5000/api/outbox/messages/0254efbf-2828-4a26-9085-df4e62ed03e3/reset' \
 --header 'Authorization: Bearer <token>'
 ```
 
-Get a list of outbox messages that have failed
+Get a list of outbox messages that have failed:
 ```bash
 curl --location --request DELETE 'localhost:5000/api/outbox/messages/0316fc22-9e12-44d0-b44e-eed684a57768' \
 --header 'Authorization: Bearer <token>'

--- a/src/Cortside.DomainEvent.Mvc/README.md
+++ b/src/Cortside.DomainEvent.Mvc/README.md
@@ -1,0 +1,23 @@
+## Cortside.DomainEvent.Mvc
+
+This library provides a controller to be able to interact with outbox messages that have failed.  Specifically to enumerate them, retry them, and delete them.
+
+### Examples
+
+Get a list of outbox messages that have failed
+```bash
+curl --location 'localhost:5000/api/outbox/messages?pageNumber=1&pageSize=10' \
+--header 'Authorization: Bearer <token>'
+```
+
+Reset an outbox message that has failed to queued with new attempts
+```bash
+curl --location --request POST 'localhost:5000/api/outbox/messages/0254efbf-2828-4a26-9085-df4e62ed03e3/reset' \
+--header 'Authorization: Bearer <token>'
+```
+
+Get a list of outbox messages that have failed
+```bash
+curl --location --request DELETE 'localhost:5000/api/outbox/messages/0316fc22-9e12-44d0-b44e-eed684a57768' \
+--header 'Authorization: Bearer <token>'
+```

--- a/src/Cortside.DomainEvent.Stub/DomainEventPublisherStub.cs
+++ b/src/Cortside.DomainEvent.Stub/DomainEventPublisherStub.cs
@@ -3,11 +3,15 @@ using Amqp;
 using Microsoft.Extensions.Logging;
 
 namespace Cortside.DomainEvent.Stub {
-    public class DomainEventPublisherStub : BaseDomainEventPublisher {
+    public class DomainEventPublisherStub : BaseDomainEventPublisher, IDomainEventPublisherSession {
         private readonly IStubBroker queue;
 
         public DomainEventPublisherStub(DomainEventPublisherSettings settings, ILogger<DomainEventPublisherStub> logger, IStubBroker queue) : base(settings, logger) {
             this.queue = queue;
+        }
+
+        public override IDomainEventPublisherSession BeginSession() {
+            return this;
         }
 
         protected override Task SendAsync(Message message, EventProperties properties) {
@@ -15,6 +19,10 @@ namespace Cortside.DomainEvent.Stub {
             Statistics.Instance.Publish();
             Logger.LogInformation($"Published message {message.Properties.MessageId}");
             return Task.CompletedTask;
+        }
+
+        public void Dispose() {
+            // nothing to do
         }
     }
 }

--- a/src/Cortside.DomainEvent.sln
+++ b/src/Cortside.DomainEvent.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cortside.DomainEvent.Health
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Health", "Health", "{B20D5398-646A-4E79-A0EE-2A3E3C0202B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cortside.DomainEvent.Mvc", "Cortside.DomainEvent.Mvc\Cortside.DomainEvent.Mvc.csproj", "{6CF62844-B0B8-47EC-B419-740B8B12E64A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +74,10 @@ Global
 		{3598A166-5AD1-4F36-94F0-CFB4BE2BF7A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3598A166-5AD1-4F36-94F0-CFB4BE2BF7A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3598A166-5AD1-4F36-94F0-CFB4BE2BF7A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CF62844-B0B8-47EC-B419-740B8B12E64A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CF62844-B0B8-47EC-B419-740B8B12E64A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CF62844-B0B8-47EC-B419-740B8B12E64A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CF62844-B0B8-47EC-B419-740B8B12E64A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -85,6 +91,7 @@ Global
 		{91328F03-1FAB-4B24-A64D-F9D5249264E2} = {2A7993DF-77BD-4FC1-9A13-28BAACCB30A4}
 		{FF026CE3-3D6A-4F19-BA29-FDBD777ADF65} = {2A7993DF-77BD-4FC1-9A13-28BAACCB30A4}
 		{3598A166-5AD1-4F36-94F0-CFB4BE2BF7A0} = {B20D5398-646A-4E79-A0EE-2A3E3C0202B5}
+		{6CF62844-B0B8-47EC-B419-740B8B12E64A} = {4BE176EB-A10A-415E-97EB-BE7D1862DA56}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DD00D9E8-8D42-40AE-9315-0D447B0C5275}

--- a/src/Cortside.DomainEvent/BaseDomainEventPublisher.cs
+++ b/src/Cortside.DomainEvent/BaseDomainEventPublisher.cs
@@ -32,6 +32,8 @@ namespace Cortside.DomainEvent {
         protected ILogger Logger { get; }
         protected string ConnectionString { get; }
 
+        public abstract IDomainEventPublisherSession BeginSession();
+
         public Task PublishAsync<T>(T @event) where T : class {
             var properties = new EventProperties();
             var message = CreateMessage(@event, properties);

--- a/src/Cortside.DomainEvent/Constants.cs
+++ b/src/Cortside.DomainEvent/Constants.cs
@@ -1,6 +1,5 @@
 namespace Cortside.DomainEvent {
     public static class Constants {
-        public const string foo = "foo";
         public const string MESSAGE_TYPE_KEY = "Message.Type.FullName";
         public const string SCHEDULED_ENQUEUE_TIME_UTC = "x-opt-scheduled-enqueue-time";
     }

--- a/src/Cortside.DomainEvent/DomainEventPublisher.cs
+++ b/src/Cortside.DomainEvent/DomainEventPublisher.cs
@@ -67,6 +67,7 @@ namespace Cortside.DomainEvent {
                 }
                 var sender = new SenderLink(session, Settings.Service + Guid.NewGuid().ToString(), attach, null);
                 sender.Closed += OnClosed;
+                Logger.LogTrace("SenderLink established");
 
                 try {
                     await sender.SendAsync(message).ConfigureAwait(false);
@@ -104,6 +105,7 @@ namespace Cortside.DomainEvent {
         }
 
         private void OnClosed(IAmqpObject sender, Error error) {
+            Logger.LogTrace("OnClosed called");
             if (Error == null && sender.Error != null) {
                 Error = new DomainEventError {
                     Condition = sender.Error.Condition.ToString(),

--- a/src/Cortside.DomainEvent/DomainEventPublisher.cs
+++ b/src/Cortside.DomainEvent/DomainEventPublisher.cs
@@ -6,9 +6,9 @@ using Amqp.Framing;
 using Microsoft.Extensions.Logging;
 
 namespace Cortside.DomainEvent {
-    public class DomainEventPublisher : BaseDomainEventPublisher, IDisposable {
+    public class DomainEventPublisher : BaseDomainEventPublisher, IDomainEventPublisherSession, IDisposable {
         private Connection conn;
-        private readonly Session sharedSession;
+        private Session sharedSession;
 
         public new event PublisherClosedCallback Closed;
 
@@ -26,6 +26,13 @@ namespace Cortside.DomainEvent {
             if (conn == null) {
                 conn = new Connection(new Address(ConnectionString));
             }
+        }
+
+        public override IDomainEventPublisherSession BeginSession() {
+            Connect();
+            sharedSession = new Session(conn);
+
+            return this;
         }
 
         protected override async Task SendAsync(Message message, EventProperties properties) {

--- a/src/Cortside.DomainEvent/IDomainEventPublisher.cs
+++ b/src/Cortside.DomainEvent/IDomainEventPublisher.cs
@@ -8,6 +8,8 @@ namespace Cortside.DomainEvent {
         event PublisherClosedCallback Closed;
         DomainEventError Error { get; set; }
 
+        IDomainEventPublisherSession BeginSession();
+
         Task PublishAsync<T>(T @event) where T : class;
         Task PublishAsync<T>(T @event, string correlationId) where T : class;
         Task PublishAsync<T>(T @event, EventProperties properties) where T : class;

--- a/src/Cortside.DomainEvent/IDomainEventPublisherSession.cs
+++ b/src/Cortside.DomainEvent/IDomainEventPublisherSession.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace Cortside.DomainEvent {
+    public interface IDomainEventPublisherSession : IDomainEventPublisher, IDisposable {
+    }
+}


### PR DESCRIPTION
* Add the ability to override MaximumRetryCount by EventType:
  ```json
  OutboxHostedService": {
      "BatchSize":  10,
      "Enabled": true,
      "Interval": 5,
      "PurgePublished": true,
      "MaximumPublishCount": 10,
      "PublishRetryInterval": 60,
      "Overrides": [
          {
              "EventType": "MyEvent",
              "MaximumPublishCount": 5
          },
          {
              "EventType": "OtherEvent",
              "MaximumPublishCount": 10
          }
      ]
  }
  ```
  * Overrides can be null or empty collection, they do not have to be defined if it's desired that all have the same publish count
* Add a column to contain the number of remaining attempts to publish instead of using the publish count, allowing for additional retries
  * Default to 10 for existing rows on update
* Add controller that can be used to expose functionality to:
  * Get failed outbox messages (permission: GetOutboxMessages)
  * Retry failed outbox message (permission: RetryOutboxMessage)
  * Delete failed outbox message (permission: DeleteOutboxMessage)
```csharp
            // add controllers and set api defaults
            var mvcBuilder = services.AddApiDefaults(InternalDateTimeHandling.Utc, options => {
                options.Filters.Add<MessageExceptionResponseFilter>();
            });
            mvcBuilder.PartManager.ApplicationParts.Add(new AssemblyPart(typeof(OutboxController).Assembly));
```
